### PR TITLE
Remove info from README that is already in the Igluctl docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,86 +4,14 @@
 ![CD][cd]
 [![License][license-image]][license]
 
-Igluctl is command-line tool, that enables you to perform the most common tasks with **[Iglu][iglu]** schema registries, i.e.:
+Igluctl is a command-line tool that enables you to perform the most common tasks with **[Iglu][iglu]** schema registries, i.e.:
 
 * Linting (validating) JSON Schemas
 * Generating corresponding Redshift tables definition and JSON path files for JSON Schemas
-* Publish JSON Schemas stored locally to Iglu schema registries
-* Publish JSON Schemas (or any other files) stored locally to AWS S3
+* Publishing JSON Schemas stored locally to Iglu schema registries
+* Publishing JSON Schemas (or any other files) stored locally to AWS S3
 
-For complete documenation on Igluctl please refer to the [technical documentation][technical-documentation].
-
-## User Quickstart
-
-Make sure you have [Oracle JRE 8][jre] installed.
-
-Artifacts are attached to GitHub releases. e.g. 0.10.1 can be downloaded from
-
-```
-https://github.com/snowplow-incubator/igluctl/releases/download/0.10.1/igluctl
-```
-
-### Windows
-
-`igluctl` is a single executable file.
-
-To run it you can use following format:
-
-```bash
-$ java -jar igluctl lint $SCHEMAS_DIR
-```
-
-Below and everywhere in documentation you'll find example commands without `java -jar` prefix, which is Windows-specific.
-
-### Mac OS X and Linux
-
-You can run igluctl using following commands:
-
-```bash
-$ ./igluctl lint $SCHEMAS_DIR
-```
-
-## CLI
-
-### Generate DDL
-
-You can transform JSON Schema into Redshift (other storages are coming) DDL, using `igluctl static generate` command.
-
-```bash
-$ ./igluctl static generate $SCHEMAS_DIR
-```
-
-`$SCHEMAS_DIR` should be the path to the JSON Schemas stored locally that are to be validated.
-
-### Publish JSON Schemas to a remote Iglu Schema Registry
-
-You can publish your JSON Schemas from local filesystem to Iglu Scala Registry using `igluctl static push` command.
-
-
-```bash
-$ ./igluctl static push $SCHEMAS_DIR $IGLU_HOST $APIKEY
-```
-
-If you are running an s3 backed Iglu Static Server Registry you can publish schemas as follows:
-
-```
-$ ./igluctl static s3cp $SCHEMAS_DIR $S3BUCKET --accessKeyId $ACCESS_KEY_ID --secretAccessKey $SECRET_ACCESS_KEY --region $AWS_REGION
-```
-
-Igluctl will closely follow [AWS CLI][aws-cli] tools behavior while looking for credentials, which means you can omit `accessKeyId` and `secretKeyId` options
-if you have AWS `default` profile or appropriate environment variables.
-
-### Linting
-
-You can check your JSON Schema for vairous common mistakes using `igluctl lint` command.
-
-```bash
-$ ./igluctl lint $SCHEMAS_DIR
-```
-
-This check will include JSON Syntax validation (`required` is not empty, `maximum` is integer etc)
-and also "sanity check", which checks that particular JSON Schema can always validate at least one possible JSON.
-
+For complete documentation on Igluctl please refer to the [technical documentation][technical-documentation].
 
 ## Copyright and License
 
@@ -102,12 +30,8 @@ limitations under the License.
 [license-image]: http://img.shields.io/badge/license-Apache--2-blue.svg?style=flat
 [license]: http://www.apache.org/licenses/LICENSE-2.0
 
-[iglu]: https://github.com/snowplow/iglu
-[schema-guru]: https://github.com/snowplow/schema-guru
-[technical-documentation]: https://github.com/snowplow/iglu/wiki/Igluctl
-
-[jre]: http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html
-[aws-cli]: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence
+[iglu]: https://docs.snowplow.io/docs/pipeline-components-and-applications/iglu/
+[technical-documentation]: https://docs.snowplow.io/docs/pipeline-components-and-applications/iglu/igluctl-2/
 
 [ci]: https://github.com/snowplow-incubator/igluctl/workflows/CI/badge.svg
 [cd]: https://github.com/snowplow-incubator/igluctl/workflows/CD/badge.svg


### PR DESCRIPTION
A lot of the README is also available here in the Igluctl docs:
https://docs.snowplow.io/docs/pipeline-components-and-applications/iglu/igluctl-2/

I think that it makes sense for info about running/using Igluctl to live in the docs, and info about developing Igluctl to live in the README. Either way, info shouldn't be duplicated in two places.

All the info removed in this change was already in the docs, except the difference between running Igluctl on Windows vs OS X/Linux, so there is a PR to add that info to the docs here: 
https://github.com/snowplow/documentation/pull/282