### PR TITLE
Add verbose flag to verify redshift

### DIFF
--- a/src/main/scala/com.snowplowanalytics.iglu/ctl/Command.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/ctl/Command.scala
@@ -116,6 +116,7 @@ object Command {
   val selfDescribingSchema = Opts.option[SchemaKey]("schema", "Schema to check against. It should have iglu:<URI> format")
   val igluServerUrl = Opts.option[Server.HttpUrl]("server", "Iglu Server URL")
   val igluServerApiKey = Opts.option[UUID]("apikey", "Iglu Server Read ApiKey (non master)").orNone
+  val verbose = Opts.flag("verbose", "Whether verify-redshift should print detailed report or not", "v").orFalse
   val dbSchema = Opts.option[String]("dbschema", "Database schema").withDefault("atomic")
 
   val singleTableCheck = (igluResolver, selfDescribingSchema).mapN(SingleTableCheck.apply)
@@ -146,7 +147,7 @@ object Command {
     input.map(VerifyParquet.apply)
   }
   val verifyRedshift = Opts.subcommand("redshift", "Detect breaking changes between JSON schemas for Redshift") {
-    (igluServerUrl, igluServerApiKey).mapN(VerifyRedshift.apply)
+    (igluServerUrl, igluServerApiKey, verbose).mapN(VerifyRedshift.apply)
   }
 
   val verify = Opts.subcommand("verify", "Detect breaking changes between JSON schemas for different targets") {
@@ -199,7 +200,7 @@ object Command {
 
   case class VerifyParquet(input: Path) extends VerifyCommand
 
-  case class VerifyRedshift(igluServerUrl: Server.HttpUrl, apiKey: Option[UUID]) extends VerifyCommand
+  case class VerifyRedshift(igluServerUrl: Server.HttpUrl, apiKey: Option[UUID], verbose: Boolean) extends VerifyCommand
 
   case class Lint(input: Path,
                   skipChecks: List[Linter],

--- a/src/main/scala/com.snowplowanalytics.iglu/ctl/commands/VerifyRedshift.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/ctl/commands/VerifyRedshift.scala
@@ -3,12 +3,9 @@ package com.snowplowanalytics.iglu.ctl.commands
 import cats.data.NonEmptyList
 import cats.implicits._
 import cats.effect.IO
-
-import com.snowplowanalytics.iglu.core.SchemaCriterion
+import com.snowplowanalytics.iglu.core.{SchemaCriterion, SchemaKey}
 import com.snowplowanalytics.iglu.schemaddl.redshift._
-
 import org.http4s.client.Client
-
 import com.snowplowanalytics.iglu.ctl.{Command, Result}
 import CommandUtils._
 
@@ -18,23 +15,31 @@ object VerifyRedshift {
     getAllSchemasFromServer(command.igluServerUrl, command.apiKey, httpClient)
       .leftMap(NonEmptyList.one)
       .map(groupSchemasToFamilies)
-      .map(_.flatMap(verifyFamily))
-      .map(prepareOutputMessage)
+      .map(_.map(verifyFamily))
+      .map(prepareOutputMessage(_, command.verbose))
   }
 
-  private def verifyFamily(schemaFamily: SchemaFamily):  Option[SchemaCriterion] = {
-    val recoveryModels = foldMapMergeRedshiftSchemas(schemaFamily).recoveryModels
-    if (recoveryModels.nonEmpty) {
-      val key = recoveryModels.head._1
-      SchemaCriterion(key.vendor, key.name, key.format, key.version.model).some
-    } else None
+  private def verifyFamily(schemaFamily: SchemaFamily): Map[SchemaKey, NonEmptyList[String]] = {
+    foldMapMergeRedshiftSchemas(schemaFamily)
+      .recoveryModels
+      .view
+      .mapValues(_.errorAsStrings)
+      .toMap
   }
 
-  private def prepareOutputMessage(schemaCriterions: List[SchemaCriterion]): List[String] = {
-    if (schemaCriterions.nonEmpty) {
-      schemaCriterions.map(_.asString)
-    } else {
-      List("No breaking changes detected")
+  private def prepareOutputMessage(verifiedFamilies: List[Map[SchemaKey, NonEmptyList[String]]], verbose: Boolean): List[String] = {
+    val result = verifiedFamilies.flatMap { family =>
+      val optKey = family.headOption.map(_._1)
+      val optCriterion = optKey.map(key =>  SchemaCriterion(key.vendor, key.name, key.format, key.version.model))
+      optCriterion.fold[List[String]](Nil) { criterion =>
+        if (verbose) {
+          s"${criterion.asString}:" :: family.toList.sorted.map { case (sk, nel) =>
+            s"  ${sk.toSchemaUri}: ${nel.mkString_("[", "," ,"]")}"
+          }
+        }
+        else List(criterion.asString)
+      }
     }
+    if (result.isEmpty) List("No breaking changes detected") else result
   }
 }

--- a/src/test/scala/com/snowplowanalytics/iglu/ctl/CommandSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/ctl/CommandSpec.scala
@@ -44,6 +44,8 @@ class CommandSpec extends Specification { def is = s2"""
     extracts verify parquet command $e9
     extracts verify redshift command without apikey $e10
     extracts verify redshift command with apikey $e11
+    extracts verify redshift command with long verbose flag $e12
+    extracts verify redshift command with short verbose flag $e13
   """
 
   def e1 = {
@@ -115,13 +117,27 @@ class CommandSpec extends Specification { def is = s2"""
     val verify = Command.parse("verify redshift --server http://localhost:8080".split(" ").toList)
     val url = Server.HttpUrl.parse("http://localhost:8080").getOrElse(throw new RuntimeException("Invalid URI"))
 
-    verify must beRight(Command.VerifyRedshift(url, None))
+    verify must beRight(Command.VerifyRedshift(url, None, verbose = false))
   }
 
   def e11 = {
     val verify = Command.parse("verify redshift --server http://localhost:8080 --apikey e82d494f-ba11-4206-b78a-d2aaedeeab44".split(" ").toList)
     val url = Server.HttpUrl.parse("http://localhost:8080").getOrElse(throw new RuntimeException("Invalid URI"))
 
-    verify must beRight(Command.VerifyRedshift(url, UUID.fromString("e82d494f-ba11-4206-b78a-d2aaedeeab44").some))
+    verify must beRight(Command.VerifyRedshift(url, UUID.fromString("e82d494f-ba11-4206-b78a-d2aaedeeab44").some, verbose = false))
+  }
+
+  def e12 = {
+    val verify = Command.parse("verify redshift --server http://localhost:8080 --apikey e82d494f-ba11-4206-b78a-d2aaedeeab44 --verbose".split(" ").toList)
+    val url = Server.HttpUrl.parse("http://localhost:8080").getOrElse(throw new RuntimeException("Invalid URI"))
+
+    verify must beRight(Command.VerifyRedshift(url, UUID.fromString("e82d494f-ba11-4206-b78a-d2aaedeeab44").some, verbose = true))
+  }
+
+  def e13 = {
+    val verify = Command.parse("verify redshift --server http://localhost:8080 --apikey e82d494f-ba11-4206-b78a-d2aaedeeab44 -v".split(" ").toList)
+    val url = Server.HttpUrl.parse("http://localhost:8080").getOrElse(throw new RuntimeException("Invalid URI"))
+
+    verify must beRight(Command.VerifyRedshift(url, UUID.fromString("e82d494f-ba11-4206-b78a-d2aaedeeab44").some, verbose = true))
   }
 }

--- a/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/ITHelpers.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/ITHelpers.scala
@@ -1,0 +1,67 @@
+package com.snowplowanalytics.iglu.ctl.commands
+
+import cats.effect._
+import cats.effect.implicits._
+import com.dimafeng.testcontainers.MockServerContainer
+import org.mockserver.client.MockServerClient
+import org.mockserver.mock.Expectation
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
+import org.testcontainers.lifecycle.Startable
+
+import scala.concurrent.ExecutionContext
+
+object ITHelpers {
+
+  val executionContext: ExecutionContext = ExecutionContext.global
+  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(executionContext)
+  implicit val ioTimer: Timer[IO] = IO.timer(executionContext)
+
+  def testSchema(fields: String): String =
+    s"""
+       |{
+       |  "$$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+       |  "description": "Test schema",
+       |  "self": {
+       |    "vendor": "com.test",
+       |    "name": "test",
+       |    "format": "jsonschema",
+       |    "version": "1-0-0"
+       |  },
+       |  "type": "object",
+       |  "properties": $fields
+       |}
+       |""".stripMargin
+
+  def testSchemaWrongType(fields: String, minor: Int): String =
+    s"""
+       |{
+       |  "$$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+       |  "description": "Test schema",
+       |  "self": {
+       |    "vendor": "com.test",
+       |    "name": "test",
+       |    "format": "jsonschema",
+       |    "version": "1-0-$minor"
+       |  },
+       |  "type": "object",
+       |  "properties": $fields
+       |}
+       |""".stripMargin
+
+  def mkContainer[A <: Startable](container: A): Resource[IO, A] =
+    Resource.make {
+      IO {
+        container.start()
+        container
+      }
+    }(container => IO(container.stop()))
+
+
+  def mockIgluSchemas(server: MockServerContainer, igluSchemas: List[String]): Array[Expectation] = {
+    val mockClient = new MockServerClient(server.host, server.serverPort)
+    mockClient
+      .when(request().withPath("/api/schemas"))
+      .respond(response().withStatusCode(200).withBody(igluSchemas.mkString("[", ",", "]")))
+  }
+}

--- a/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/ITHelpers.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/ITHelpers.scala
@@ -17,7 +17,7 @@ object ITHelpers {
   implicit val ioContextShift: ContextShift[IO] = IO.contextShift(executionContext)
   implicit val ioTimer: Timer[IO] = IO.timer(executionContext)
 
-  def testSchema(fields: String): String =
+  def testSchema(fields: String, version: String): String =
     s"""
        |{
        |  "$$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
@@ -26,23 +26,7 @@ object ITHelpers {
        |    "vendor": "com.test",
        |    "name": "test",
        |    "format": "jsonschema",
-       |    "version": "1-0-0"
-       |  },
-       |  "type": "object",
-       |  "properties": $fields
-       |}
-       |""".stripMargin
-
-  def testSchemaWrongType(fields: String, minor: Int): String =
-    s"""
-       |{
-       |  "$$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
-       |  "description": "Test schema",
-       |  "self": {
-       |    "vendor": "com.test",
-       |    "name": "test",
-       |    "format": "jsonschema",
-       |    "version": "1-0-$minor"
+       |    "version": "$version"
        |  },
        |  "type": "object",
        |  "properties": $fields

--- a/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/TableCheckITSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/TableCheckITSpec.scala
@@ -52,7 +52,7 @@ class TableCheckITSpec extends Specification {
               |		"product_4096": {"type": ["string", "number"]},
               |		"product_bool_int": {"type": ["boolean", "integer"]}
               |	}
-              |""".stripMargin))
+              |""".stripMargin, "1-0-0"))
         )
         result must beRight(List(
           """Matched:
@@ -64,7 +64,7 @@ class TableCheckITSpec extends Specification {
       "duplicated tables but in different schemas are defined in a database" in {
         process(
           databaseDefinition = "database/duplicated_tables.sql",
-          igluSchemas = List(testSchema(fields = """{ "char": {"type": "string"} }"""))
+          igluSchemas = List(testSchema(fields = """{ "char": {"type": "string"} }""", "1-0-0"))
         ) must beRight(List(
           """Matched:
             |Table for iglu:com.test/test/jsonschema/1-0-0 is matched
@@ -93,7 +93,7 @@ class TableCheckITSpec extends Specification {
               |		"char": {"type": "string", "minLength": 10, "maxLength": 10},
               |		"varchar": {"type": "string", "maxLength": 10}
               |	}
-              |""".stripMargin))
+              |""".stripMargin, "1-0-0"))
         )
         result must beRight(List(
           """Unmatched:
@@ -112,7 +112,7 @@ class TableCheckITSpec extends Specification {
               |   "wrong_type": { "type": "integer" },
               |   "wrong_nullability": { "type": "string" },
               |   "only_in_schema": { "type": "string" }
-              |}""".stripMargin))
+              |}""".stripMargin, "1-0-0"))
         )
         result must beRight(List(
           """Unmatched:
@@ -140,16 +140,16 @@ class TableCheckITSpec extends Specification {
         val result = process(
           databaseDefinition = "database/broken-storage-2.sql",
           igluSchemas = List(
-            testSchemaWrongType(fields =
+            testSchema(fields =
               """
                 |{
                 |   "wrong_type": { "type": "integer", "maximum": 65111 }
-                |}""".stripMargin, 0),
-            testSchemaWrongType(fields =
+                |}""".stripMargin, "1-0-0"),
+            testSchema(fields =
             """
               |{
               |   "wrong_type": { "type": "integer" }
-              |}""".stripMargin, 1))
+              |}""".stripMargin, "1-0-1"))
         )
         result must beRight(List(
           """Unmatched:

--- a/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/TableCheckITSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/TableCheckITSpec.scala
@@ -16,6 +16,7 @@ import cats.effect.{ContextShift, IO, Resource, Timer}
 import com.dimafeng.testcontainers.{JdbcDatabaseContainer, MockServerContainer, PostgreSQLContainer}
 import com.snowplowanalytics.iglu.ctl.commands.TableCheckITSpec._
 import com.snowplowanalytics.iglu.ctl.{Command, Server}
+import com.snowplowanalytics.iglu.ctl.commands.ITHelpers._
 import org.http4s.Uri
 import org.http4s.client.Client
 import org.http4s.ember.client.EmberClientBuilder
@@ -165,7 +166,7 @@ class TableCheckITSpec extends Specification {
                       igluSchemas: List[String]) = {
     prepareResources(databaseDefinition)
       .use { resources =>
-        val command = prapareCommand(resources.database, resources.igluServer)
+        val command = prepareCommand(resources.database, resources.igluServer)
         mockIgluSchemas(resources.igluServer, igluSchemas)
         TableCheck.process(command, resources.httpClient).value
       }.unsafeRunSync()
@@ -180,7 +181,7 @@ class TableCheckITSpec extends Specification {
   }
 
 
-  private def prapareCommand(database: PostgreSQLContainer,
+  private def prepareCommand(database: PostgreSQLContainer,
                              igluServer: MockServerContainer) = {
     Command.TableCheck(Command.MultipleTableCheck(
       Server.HttpUrl(Uri.unsafeFromString(igluServer.endpoint)), None),
@@ -195,73 +196,15 @@ class TableCheckITSpec extends Specification {
     )
   }
 
-  private def mkContainer[A <: Startable](container: A): Resource[IO, A] =
-    Resource.make {
-      IO {
-        container.start()
-        container
-      }
-    }(container => IO(container.stop()))
-
-
-  private def mockIgluSchemas(server: MockServerContainer,
-                              igluSchemas: List[String]) = {
-    val mockClient = new MockServerClient(server.host, server.serverPort)
-    mockClient
-      .when(request().withPath("/api/schemas"))
-      .respond(response().withStatusCode(200).withBody(igluSchemas.mkString("[", ",", "]")))
-
-  }
-
   private def createDatabase(initScript: String): PostgreSQLContainer = {
     val params = JdbcDatabaseContainer.CommonParams(initScriptPath = Option(initScript))
     PostgreSQLContainer.Def(
       commonJdbcParams = params
     ).createContainer()
   }
-
-  private def testSchema(fields: String): String =
-    s"""
-       |{
-       |  "$$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
-       |  "description": "Test schema",
-       |  "self": {
-       |    "vendor": "com.test",
-       |    "name": "test",
-       |    "format": "jsonschema",
-       |    "version": "1-0-0"
-       |  },
-       |  "type": "object",
-       |  "properties": $fields
-       |}    
-       |""".stripMargin
-
-  private def testSchemaWrongType(fields: String, minor: Int): String =
-    s"""
-       |{
-       |  "$$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
-       |  "description": "Test schema",
-       |  "self": {
-       |    "vendor": "com.test",
-       |    "name": "test",
-       |    "format": "jsonschema",
-       |    "version": "1-0-$minor"
-       |  },
-       |  "type": "object",
-       |  "properties": $fields
-       |}    
-       |""".stripMargin
-
-
 }
 
 object TableCheckITSpec {
-
-  private val executionContext: ExecutionContext = ExecutionContext.global
-  implicit val ioContextShift: ContextShift[IO] = IO.contextShift(executionContext)
-  implicit val ioTimer: Timer[IO] = IO.timer(executionContext)
-
-
   final case class TestResources(database: PostgreSQLContainer,
                                  igluServer: MockServerContainer,
                                  httpClient: Client[IO])

--- a/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/VerifyRedshiftITSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/VerifyRedshiftITSpec.scala
@@ -23,11 +23,11 @@ class VerifyRedshiftITSpec extends Specification {
           testSchema(fields =
           """
               |{"cacheSize": {"type": "integer", "minimum": 0}}
-              |""".stripMargin),
-          testSchemaWrongType(fields =
+              |""".stripMargin, "1-0-0"),
+          testSchema(fields =
             """
               |{"cacheSize": {"type": "number"}}
-              |""".stripMargin, 1)
+              |""".stripMargin, "1-0-1")
         ),
         verbose = false
       )
@@ -39,11 +39,11 @@ class VerifyRedshiftITSpec extends Specification {
           testSchema(fields =
             """
               |{"cacheSize": {"type": "integer", "minimum": 0}}
-              |""".stripMargin),
-          testSchemaWrongType(fields =
+              |""".stripMargin, "1-0-0"),
+          testSchema(fields =
             """
               |{"cacheSize": {"type": "number"}}
-              |""".stripMargin, 1)
+              |""".stripMargin, "1-0-1")
         ),
         verbose = true
       )
@@ -58,11 +58,11 @@ class VerifyRedshiftITSpec extends Specification {
           testSchema(fields =
             """
               |{"cacheSize": {"type": "number"}}
-              |""".stripMargin),
-          testSchemaWrongType(fields =
+              |""".stripMargin, "1-0-0"),
+          testSchema(fields =
             """
               |{"cacheSize": {"type": "integer"}}
-              |""".stripMargin, 1)
+              |""".stripMargin, "1-0-1")
         ),
         verbose = false
       )

--- a/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/VerifyRedshiftITSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/iglu/ctl/commands/VerifyRedshiftITSpec.scala
@@ -1,0 +1,101 @@
+package com.snowplowanalytics.iglu.ctl.commands
+
+import cats.data.NonEmptyList
+import cats.effect.{IO, Resource}
+import cats.effect.implicits._
+import com.dimafeng.testcontainers.MockServerContainer
+import com.snowplowanalytics.iglu.ctl.{Command, Common, Server}
+import com.snowplowanalytics.iglu.ctl.commands.ITHelpers._
+import org.http4s.Uri
+import org.http4s.client.Client
+import org.http4s.ember.client.EmberClientBuilder
+import org.specs2.mutable.Specification
+
+
+class VerifyRedshiftITSpec extends Specification {
+
+  import VerifyRedshiftITSpec._
+  
+  "verify redshift command" should {
+    "return message about breaking schemas when verbose mode is disabled" in {
+      val result = process(
+        igluSchemas = List(
+          testSchema(fields =
+          """
+              |{"cacheSize": {"type": "integer", "minimum": 0}}
+              |""".stripMargin),
+          testSchemaWrongType(fields =
+            """
+              |{"cacheSize": {"type": "number"}}
+              |""".stripMargin, 1)
+        ),
+        verbose = false
+      )
+      result must beRight(List("iglu:com.test/test/jsonschema/1-*-*"))
+    }
+    "return message about breaking schemas when verbose mode is enabled" in {
+      val result = process(
+        igluSchemas = List(
+          testSchema(fields =
+            """
+              |{"cacheSize": {"type": "integer", "minimum": 0}}
+              |""".stripMargin),
+          testSchemaWrongType(fields =
+            """
+              |{"cacheSize": {"type": "number"}}
+              |""".stripMargin, 1)
+        ),
+        verbose = true
+      )
+      result must beRight(List(
+        "iglu:com.test/test/jsonschema/1-*-*:",
+        "  iglu:com.test/test/jsonschema/1-0-1: [Incompatible types in column cache_size old RedshiftBigInt new RedshiftDouble]"
+      ))
+    }
+    "return message about no breaking changes detected" in {
+      val result = process(
+        igluSchemas = List(
+          testSchema(fields =
+            """
+              |{"cacheSize": {"type": "number"}}
+              |""".stripMargin),
+          testSchemaWrongType(fields =
+            """
+              |{"cacheSize": {"type": "integer"}}
+              |""".stripMargin, 1)
+        ),
+        verbose = false
+      )
+      result must beRight(List("No breaking changes detected"))
+    }
+  }
+
+  private def process(igluSchemas: List[String], verbose: Boolean): Either[NonEmptyList[Common.Error], List[String]] = {
+    prepareResources
+      .use { resources =>
+        val command = prepareCommand(resources.igluServer, verbose)
+        mockIgluSchemas(resources.igluServer, igluSchemas)
+        VerifyRedshift.process(command, resources.httpClient).value
+      }.unsafeRunSync()
+  }
+
+  private def prepareCommand(igluServer: MockServerContainer, verbose: Boolean) = {
+    Command.VerifyRedshift(
+      Server.HttpUrl(Uri.unsafeFromString(igluServer.endpoint)),
+      None,
+      verbose
+    )
+  }
+
+  private def prepareResources: Resource[IO, TestResources] = {
+    for {
+      igluServer <- mkContainer(MockServerContainer())
+      httpClient <- EmberClientBuilder.default[IO].build
+    } yield TestResources(igluServer, httpClient)
+  }
+
+}
+
+object VerifyRedshiftITSpec {
+  final case class TestResources(igluServer: MockServerContainer, httpClient: Client[IO])
+}


### PR DESCRIPTION
ref: pdp-1239

verbose mode disabled, same as before

```bash
$ ./target/scala-2.13/igluctl verify redshift --server http://localhost:8080
iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-*-*
iglu:com.snowplowanalytics.snowplow/event_fingerprint_config/jsonschema/1-*-*
iglu:com.snowplowanalytics.snowplow.badrows/loader_runtime_error/jsonschema/1-*-*
```

verbose mode enabled, printing a list of errors per schema key explaining why it was a breaking change

```bash
$ ./target/scala-2.13/igluctl verify redshift --server http://localhost:8080 -v
iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-*-*:
  iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-2: [Incompatible types in column cache_size old RedshiftBigInt new RedshiftDouble]
  iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-3: [Incompatible types in column cache_size old RedshiftBigInt new RedshiftDouble]
iglu:com.snowplowanalytics.snowplow/event_fingerprint_config/jsonschema/1-*-*:
  iglu:com.snowplowanalytics.snowplow/event_fingerprint_config/jsonschema/1-0-1: [Incompatible types in column parameters.hash_algorithm old RedshiftChar(3) new RedshiftVarchar(6)]
iglu:com.snowplowanalytics.snowplow.badrows/loader_runtime_error/jsonschema/1-*-*:
  iglu:com.snowplowanalytics.snowplow.badrows/loader_runtime_error/jsonschema/1-0-1: [Making required column nullable error]
```